### PR TITLE
Allow specifying an acoustic prompt during generation

### DIFF
--- a/soundstorm_pytorch/soundstorm.py
+++ b/soundstorm_pytorch/soundstorm.py
@@ -979,7 +979,7 @@ class SoundStorm(nn.Module):
 
         orig_seq = rearrange(x.clone(), 'b n q -> b (n q)')
 
-        t = torch.randint(0, n - 1, (1,)).item()
+        t = torch.randint(0, n, (1,)).item()
         q = torch.randint(0, gq, (1,)).item()
 
         rand_times = torch.empty(b, device = device).uniform_(0, 1)


### PR DESCRIPTION
This allows voice-style prompting, as described in the paper:

> 3.2: Masking
>
> [...] We design our masking scheme for training accordingly. To enable voice prompting, we randomly sample a timestep t ∈ {1, . . . , T }, where T denotes the maximum sequence length, and we do not mask any tokens before this timestep.

> 3.3: Iterative Parallel Decoding
>
> Given a conditioning signal, our decoding scheme starts with all SoundStream tokens masked out except for the ones of the prompt (if provided).

The prompt tokens should be of the shape [batch, timesteps, quantizers], where the dimension of the provided quantizers is allowed to be less than the total number of quantizers for both AudioLM-like coarse token-only prompting and full coarse + fine token prompting.

I also fixed checkpoint loading from the trainer and an removed an errant assert that referenced a non-existent input.