### PR TITLE
Support automatic masking for variable length sequences with a padding value

### DIFF
--- a/soundstorm_pytorch/soundstorm.py
+++ b/soundstorm_pytorch/soundstorm.py
@@ -1053,7 +1053,7 @@ class SoundStorm(nn.Module):
         seq_mask = mask
 
         if not exists(seq_mask) and exists(self.pad_id):
-            seq_mask = (x != self.pad_id).any(dim = -1).squeeze(-1)
+            seq_mask = (x != self.pad_id).any(dim = -1)
         elif not exists(seq_mask):
             seq_mask = torch.ones((b, n), device = device, dtype = torch.bool)
 

--- a/soundstorm_pytorch/soundstorm.py
+++ b/soundstorm_pytorch/soundstorm.py
@@ -612,6 +612,7 @@ class SoundStorm(nn.Module):
         critic_loss_weight = 1.,
         num_semantic_token_ids = None,
         semantic_pad_id = -1,
+        pad_id = None,
         wav2vec_target_sample_hz = None,
         wav2vec_downsample_factor = None,
         codec_target_sample_hz = None,
@@ -625,6 +626,7 @@ class SoundStorm(nn.Module):
         dim = net.dim
         self.dim = dim
         self.num_tokens = net.codebook_size
+        self.pad_id = pad_id
 
         # set soundstream
 
@@ -1050,7 +1052,9 @@ class SoundStorm(nn.Module):
 
         seq_mask = mask
 
-        if not exists(seq_mask):
+        if not exists(seq_mask) and exists(self.pad_id):
+            seq_mask = (x != self.pad_id).any(dim = -1).squeeze(-1)
+        elif not exists(seq_mask):
             seq_mask = torch.ones((b, n), device = device, dtype = torch.bool)
 
         # maybe condition


### PR DESCRIPTION
Thanks for adding the variable length sequence handling! I had a rough cut of it in my tree and your take is much simpler 😅

This change makes it a littler easier to deal with variable length sequences using a padding value parameter (default = None) and automatically generating the correct sequence mask of shape [batch, timestep] if provided.