### PR TITLE
update: replace @beartype any with Any in ConformerWrapper

### DIFF
--- a/soundstorm_pytorch/soundstorm.py
+++ b/soundstorm_pytorch/soundstorm.py
@@ -15,7 +15,7 @@ from einops.layers.torch import Rearrange, EinMix
 
 from beartype import beartype
 from beartype.door import is_bearable
-from beartype.typing import Union, Dict, Optional, List, Optional
+from beartype.typing import Union, Dict, Optional, List, Optional, Any
 
 from soundstorm_pytorch.attend import Attend
 
@@ -494,7 +494,7 @@ class ConformerWrapper(nn.Module):
         *,
         codebook_size,
         num_quantizers,
-        conformer: Union[Conformer, Dict[str, any]],
+        conformer: Union[Conformer, Dict[str, Any]],
         grouped_quantizers = 1
     ):
         super().__init__()


### PR DESCRIPTION
`ConformerWrapper` will not import because the type for conformer is: 

```python
        conformer: Union[Conformer, Dict[str, any]],
```

when it should be 

```python
        conformer: Union[Conformer, Dict[str, Any]],
```

---

Error thrown: 

```python
---------------------------------------------------------------------------
BeartypeDecorHintNonpepException          Traceback (most recent call last)
[<ipython-input-2-712e33fc0646>](https://localhost:8080/#) in <cell line: 1>()
----> 1 from soundstorm_pytorch import SoundStorm, ConformerWrapper

26 frames
[/usr/local/lib/python3.10/dist-packages/beartype/_util/hint/nonpep/utilnonpeptest.py](https://localhost:8080/#) in die_unless_hint_nonpep(hint, is_str_valid, exception_cls, exception_prefix)
    201 
    202     # Raise a generic exception.
--> 203     raise exception_cls(
    204         f'{exception_prefix}type hint {repr(hint)} either '
    205         f'PEP-noncompliant or currently unsupported by @beartype.'

BeartypeDecorHintNonpepException: Method soundstorm_pytorch.soundstorm.ConformerWrapper.__init__() parameter "conformer" type hint <built-in function any> either PEP-noncompliant or currently unsupported by @beartype.

```